### PR TITLE
Refactor backend session utilities and add hooks

### DIFF
--- a/backend/utils/analysis.py
+++ b/backend/utils/analysis.py
@@ -1,0 +1,49 @@
+from .session import AnalysisSession, CoachingResponse
+from .parsing import extract_key_areas, extract_tips
+from typing import List
+import google.generativeai as genai
+import os
+
+# Gemini configuration is done once here
+if os.environ.get("GOOGLE_API_KEY"):
+    genai.configure(api_key=os.environ.get("GOOGLE_API_KEY"))
+model = genai.GenerativeModel('gemini-1.5-flash')
+
+
+def consolidate_session_feedback(session: AnalysisSession) -> CoachingResponse:
+    """Consolidate all feedback from a session into final assessment."""
+    all_feedback = " ".join([f.feedback for f in session.feedbackList])
+    all_areas = list({area for f in session.feedbackList for area in f.keyAreas})
+    all_tips = list({tip for f in session.feedbackList for tip in f.tips})
+
+    consolidation_prompt = (
+        f"Based on {len(session.feedbackList)} basketball dribbling video clips, "
+        "provide a comprehensive assessment.\n\n"
+        f"Accumulated feedback: {all_feedback}\n\n"
+        f"Key areas identified: {', '.join(all_areas)}\n\n"
+        "Please consolidate this into:\n"
+        "1. A comprehensive assessment highlighting the main patterns\n"
+        "2. The top 3 most important areas to focus on\n"
+        "3. Specific drill recommendation based on the identified needs\n"
+        "4. Primary technique focus area\n"
+    )
+
+    try:
+        consolidation_response = model.generate_content([consolidation_prompt])
+        consolidated_text = consolidation_response.text
+
+        feedback = CoachingResponse(
+            feedback=consolidated_text,
+            tips=extract_tips(consolidated_text),
+        )
+        if not feedback.technique and all_areas:
+            feedback.technique = all_areas[0]
+        return feedback
+    except Exception as e:
+        # Basic fallback
+        return CoachingResponse(
+            feedback=f"Based on {len(session.feedbackList)} clips, focus on {', '.join(all_areas[:3])}",
+            technique=all_areas[0] if all_areas else "Ball Control",
+            tips=all_tips[:3],
+            drillSuggestion="Basic Stationary Dribble",
+        )

--- a/backend/utils/parsing.py
+++ b/backend/utils/parsing.py
@@ -1,0 +1,47 @@
+from typing import List
+
+
+def extract_key_areas(feedback_text: str) -> List[str]:
+    """Extract key skill areas from feedback text."""
+    areas: List[str] = []
+    text_lower = feedback_text.lower()
+
+    if "control" in text_lower or "grip" in text_lower:
+        areas.append("Ball Control")
+    if any(word in text_lower for word in ["rhythm", "timing", "consistency"]):
+        areas.append("Rhythm & Timing")
+    if any(word in text_lower for word in ["posture", "stance", "position"]):
+        areas.append("Body Position")
+    if "height" in text_lower or "bounce" in text_lower:
+        areas.append("Dribble Height")
+    if any(word in text_lower for word in ["hand", "finger"]):
+        areas.append("Hand Technique")
+    if any(word in text_lower for word in ["head", "eyes", "awareness"]):
+        areas.append("Court Awareness")
+
+    return areas
+
+
+def extract_tips(feedback_text: str) -> List[str]:
+    """Extract actionable tips from feedback text."""
+    lines = feedback_text.split("\n")
+    tips: List[str] = []
+
+    for line in lines:
+        line = line.strip()
+        if any(starter in line.lower() for starter in [
+            "tip:", "try", "focus on", "practice", "work on", "remember"]):
+            clean_tip = line.lstrip("\u2022-*123456789. ").strip()
+            if clean_tip and len(clean_tip) > 10:
+                tips.append(clean_tip)
+
+    if not tips:
+        sentences = feedback_text.split(".")
+        for sentence in sentences:
+            if any(word in sentence.lower() for word in [
+                "should", "try", "focus", "keep", "maintain", "improve"]):
+                clean_sentence = sentence.strip()
+                if len(clean_sentence) > 15:
+                    tips.append(clean_sentence)
+
+    return tips[:3]

--- a/backend/utils/session.py
+++ b/backend/utils/session.py
@@ -1,0 +1,31 @@
+from pydantic import BaseModel
+from typing import List, Optional, Dict
+
+class ProgressiveFeedback(BaseModel):
+    clipNumber: int
+    feedback: str
+    keyAreas: List[str]
+    tips: List[str]
+    timestamp: str
+
+class CoachingResponse(BaseModel):
+    feedback: str
+    drillSuggestion: Optional[str] = None
+    technique: Optional[str] = None
+    tips: Optional[List[str]] = None
+
+class AnalysisSession(BaseModel):
+    sessionId: str
+    feedbackList: List[ProgressiveFeedback] = []
+    keyThemes: List[str] = []
+    skillLevel: str = "intermediate"
+    saturated: bool = False
+    consolidatedFeedback: Optional[CoachingResponse] = None
+    currentDrill: Optional[str] = None
+    drillPhase: str = "watching"
+
+# Simple in-memory store. Replace with Redis or DB in production.
+analysis_sessions: Dict[str, AnalysisSession] = {}
+
+MAX_FEEDBACK_ROUNDS = 6
+SATURATION_THRESHOLD = 5

--- a/frontend/src/hooks/useAnalysisSession.ts
+++ b/frontend/src/hooks/useAnalysisSession.ts
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+
+interface ProgressiveResponse {
+  clipNumber: number;
+  saturated: boolean;
+  feedback: { feedback: string };
+  consolidatedFeedback?: any;
+  feedbackList?: { feedback: string }[];
+  keyThemes?: string[];
+}
+
+export function useAnalysisSession() {
+  const [phase, setPhase] = useState<'initial' | 'assessing' | 'results'>('initial');
+  const [cumulative, setCumulative] = useState<string[]>([]);
+  const [consolidated, setConsolidated] = useState<any>(null);
+
+  async function sendClip(blob: Blob) {
+    let sessionId = localStorage.getItem('basketballCoachSessionId');
+    if (!sessionId) {
+      sessionId = `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+      localStorage.setItem('basketballCoachSessionId', sessionId);
+    }
+    const fd = new FormData();
+    fd.append('video', blob, 'clip.webm');
+    fd.append('sessionId', sessionId);
+    const res = await fetch(`${process.env.REACT_APP_API_URL || 'http://localhost:8000'}/progressive_analysis`, { method: 'POST', body: fd });
+    const data: ProgressiveResponse = await res.json();
+    if (data.feedbackList) {
+      setCumulative(data.feedbackList.map(f => f.feedback));
+    }
+    if (data.saturated && data.consolidatedFeedback) {
+      setConsolidated(data.consolidatedFeedback);
+      setPhase('results');
+    }
+  }
+
+  return { phase, setPhase, cumulative, consolidated, sendClip };
+}

--- a/frontend/src/hooks/useVideoRecorder.ts
+++ b/frontend/src/hooks/useVideoRecorder.ts
@@ -1,0 +1,42 @@
+import { useRef, useState, useEffect } from 'react';
+
+export interface UseVideoRecorderOptions {
+  onStop?: (blob: Blob) => void;
+}
+
+export function useVideoRecorder(options: UseVideoRecorderOptions = {}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    async function setupCamera() {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, height: 480, frameRate: 30 } });
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          videoRef.current.onloadedmetadata = () => setReady(true);
+          const recorder = new MediaRecorder(stream);
+          recorder.ondataavailable = (e) => e.data.size > 0 && chunksRef.current.push(e.data);
+          recorder.onstop = () => {
+            const blob = new Blob(chunksRef.current, { type: 'video/webm' });
+            chunksRef.current = [];
+            options.onStop?.(blob);
+          };
+          mediaRecorderRef.current = recorder;
+        }
+      } catch (err) {
+        console.error('Camera setup failed', err);
+      }
+    }
+    setupCamera();
+  }, []);
+
+  return {
+    videoRef,
+    ready,
+    start: () => mediaRecorderRef.current?.start(),
+    stop: () => mediaRecorderRef.current?.state === 'recording' && mediaRecorderRef.current.stop(),
+  };
+}


### PR DESCRIPTION
## Summary
- move session logic to `backend/utils` for easier reuse
- create placeholder React hooks for future frontend refactors
- update `main.py` to import new utilities

## Testing
- `pytest`
- `npm test -- --watchAll=false` 

------
https://chatgpt.com/codex/tasks/task_e_6863f8ab13a4832d85454ed3d0992b55