### PR TITLE
Update utils imports

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -8,15 +8,15 @@ from dotenv import load_dotenv
 import tempfile
 from typing import List, Optional, Dict, Any
 
-from .utils.session import (
+from backend.utils.session import (
     AnalysisSession,
     ProgressiveFeedback,
     CoachingResponse,
     analysis_sessions,
     SATURATION_THRESHOLD,
 )
-from .utils.parsing import extract_key_areas, extract_tips
-from .utils.analysis import consolidate_session_feedback
+from backend.utils.parsing import extract_key_areas, extract_tips
+from backend.utils.analysis import consolidate_session_feedback
 
 load_dotenv()
 


### PR DESCRIPTION
## Summary
- use absolute utils package imports in `backend/main.py`

## Testing
- `python -m uvicorn backend.main:app --port 8000 --timeout-keep-alive 1 --lifespan off --log-level critical` *(fails: No module named uvicorn)*


------
https://chatgpt.com/codex/tasks/task_e_6864023edefc832d9da640cb62552ce2