### PR TITLE
Fix backend ModuleNotFoundError

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+# Init for backend package


### PR DESCRIPTION
## Summary
- add `backend/__init__.py` so `backend` is recognized as a Python package

This allows `uvicorn backend.main:app` (per README instructions) to import
modules correctly.

## Testing
- `python -m py_compile backend/*.py backend/utils/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68640d534b40832db0405128edf033ab